### PR TITLE
Override app delegate methods for window deminiaturization

### DIFF
--- a/macOS/AppDelegate.swift
+++ b/macOS/AppDelegate.swift
@@ -2,6 +2,7 @@ import Cocoa
 import Sparkle
 
 class AppDelegate: NSObject, NSApplicationDelegate {
+
     func applicationWillFinishLaunching(_ notification: Notification) {
         // Check UserDefaults for values; if the key doesn't exist (e.g., if MacUpdatesView hasn't ever been shown),
         // bool(forKey:) returns false, so set SUUpdater.shared() appropriately.
@@ -21,4 +22,40 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             SUUpdater.shared()?.checkForUpdatesInBackground()
         }
     }
+
+    // MARK: - Window handling when miniaturized into app icon on the Dock
+    // Credit to Henry Cooper (pillboxer) on GitHub:
+    // https://github.com/tact/beta-bugs/issues/31#issuecomment-855914705
+
+    // If the window is currently minimized into the Dock, de-miniaturize it (note that if it's minimized
+    // and the user uses OPT+TAB to switch to it, it will be de-miniaturized and brought to the foreground).
+    func applicationDidBecomeActive(_ notification: Notification) {
+        print("💬 Fired:", #function)
+        if let window = NSApp.windows.first {
+            window.deminiaturize(nil)
+        }
+    }
+
+    // If we're miniaturizing the window, deactivate it as well by activating Finder.app (note that
+    // this will bring any Finder windows that are behind other apps to the foreground).
+    func applicationDidChangeOcclusionState(_ notification: Notification) {
+        print("💬 Fired:", #function)
+        if let window = NSApp.windows.first, window.isMiniaturized {
+            NSWorkspace.shared.runningApplications.first(where: {
+                $0.activationPolicy == .regular
+            })?.activate(options: .activateAllWindows)
+        }
+    }
+
+    lazy var windows = NSWindow()
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        print("💬 Fired:", #function)
+        if !flag {
+            for window in sender.windows {
+                window.makeKeyAndOrderFront(self)
+            }
+        }
+        return true
+    }
+
 }


### PR DESCRIPTION
This PR fixes #135.

There are a couple of "known issues" with this that isn't _exactly_ like an AppKit's app behaviour:

1. If there's a Finder window open, but behind some other app's window, it's brought to the foreground when WriteFreely for Mac is minimized.
2. If WriteFreely for Mac is minimized, and <kbd>option</kbd>+<kbd>tab</kbd> is used to select it, it is de-miniaturized.

Otherwise, it works pretty well. Opening a Feedback with Apple to address this workaround.
