### PR TITLE
Throw (and handle) Keychain error instead of crashing

### DIFF
--- a/Shared/Account/AccountModel.swift
+++ b/Shared/Account/AccountModel.swift
@@ -6,6 +6,9 @@ enum AccountError: Error {
     case usernameNotFound
     case serverNotFound
     case invalidServerURL
+    case couldNotSaveTokenToKeychain
+    case couldNotFetchTokenFromKeychain
+    case couldNotDeleteTokenFromKeychain
 }
 
 extension AccountError: LocalizedError {
@@ -29,6 +32,21 @@ extension AccountError: LocalizedError {
         case .invalidServerURL:
             return NSLocalizedString(
                 "Please enter a valid instance domain name. It should look like \"https://example.com\" or \"write.as\".",  // swiftlint:disable:this line_length
+                comment: ""
+            )
+        case .couldNotSaveTokenToKeychain:
+            return NSLocalizedString(
+                "There was a problem trying to save your access token to the device, please try logging in again.",
+                comment: ""
+            )
+        case .couldNotFetchTokenFromKeychain:
+            return NSLocalizedString(
+                "There was a problem trying to fetch your access token from the device, please try logging in again.",
+                comment: ""
+            )
+        case .couldNotDeleteTokenFromKeychain:
+            return NSLocalizedString(
+                "There was a problem trying to delete your access token from the device, please try logging out again.",
                 comment: ""
             )
         }

--- a/Shared/Extensions/WriteFreelyModel+APIHandlers.swift
+++ b/Shared/Extensions/WriteFreelyModel+APIHandlers.swift
@@ -10,9 +10,16 @@ extension WriteFreelyModel {
             let user = try result.get()
             fetchUserCollections()
             fetchUserPosts()
-            saveTokenToKeychain(user.token, username: user.username, server: account.server)
-            DispatchQueue.main.async {
-                self.account.login(user)
+            do {
+                try saveTokenToKeychain(user.token, username: user.username, server: account.server)
+                DispatchQueue.main.async {
+                    self.account.login(user)
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    self.loginErrorMessage = "There was a problem storing your access token to the Keychain."
+                    self.isPresentingLoginErrorAlert = true
+                }
             }
         } catch WFError.notFound {
             DispatchQueue.main.async {

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -51,18 +51,25 @@ final class WriteFreelyModel: ObservableObject {
                     print("Server URL not found")
                     return
                 }
-                guard let token = self.fetchTokenFromKeychain(
-                        username: self.account.username,
-                        server: self.account.server
-                ) else {
-                    print("Could not fetch token from Keychain")
-                    return
+                do {
+                    guard let token = try self.fetchTokenFromKeychain(
+                            username: self.account.username,
+                            server: self.account.server
+                    ) else {
+                        self.loginErrorMessage = AccountError.couldNotFetchTokenFromKeychain.localizedDescription
+                        self.isPresentingLoginErrorAlert = true
+                        return
+                    }
+
+                    self.account.login(WFUser(token: token, username: self.account.username))
+                    self.client = WFClient(for: serverURL)
+                    self.client?.user = self.account.user
+                    self.fetchUserCollections()
+                    self.fetchUserPosts()
+                } catch {
+                    self.loginErrorMessage = AccountError.couldNotFetchTokenFromKeychain.localizedDescription
+                    self.isPresentingLoginErrorAlert = true
                 }
-                self.account.login(WFUser(token: token, username: self.account.username))
-                self.client = WFClient(for: serverURL)
-                self.client?.user = self.account.user
-                self.fetchUserCollections()
-                self.fetchUserPosts()
             }
         }
 

--- a/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
+++ b/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
@@ -969,7 +969,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 612;
+				CURRENT_PROJECT_VERSION = 615;
 				DEVELOPMENT_TEAM = TPPAB4YBA6;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = iOS/Info.plist;
@@ -978,7 +978,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.abunchtell.WriteFreely-MultiPlatform";
 				PRODUCT_NAME = "WriteFreely-MultiPlatform";
 				SDKROOT = iphoneos;
@@ -993,7 +993,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 612;
+				CURRENT_PROJECT_VERSION = 615;
 				DEVELOPMENT_TEAM = TPPAB4YBA6;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = iOS/Info.plist;
@@ -1002,7 +1002,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.abunchtell.WriteFreely-MultiPlatform";
 				PRODUCT_NAME = "WriteFreely-MultiPlatform";
 				SDKROOT = iphoneos;


### PR DESCRIPTION
This PR closes #189.

Previously, if we weren't able to read from or write to the system Keychain, we threw a `fatalError` — the assumption being that if the Keychain wasn't available, something had gone horribly wrong with the device, and so crashing was a reasonable course of action.

[Turns out](https://stackoverflow.com/questions/43125168/ios-app-startup-and-protected-data-events), it's possible that the Keychain has just taken too long to decrypt at app launch, and so in that case we shouldn't crash, but rather prompt the user to retry their action.