### PR TITLE
Bump writefreely-swift package minimum version

### DIFF
--- a/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
+++ b/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
@@ -1445,7 +1445,7 @@
 			repositoryURL = "https://github.com/writefreely/writefreely-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.3.4;
+				minimumVersion = 0.3.5;
 			};
 		};
 		17D4926327947B4D0035BD7E /* XCRemoteSwiftPackageReference "Sparkle" */ = {


### PR DESCRIPTION
This PR addresses, but does not close, #204.

It sets the minimum version of the swift package to 0.3.5, to pull in the silent-failure fixes made in writefreely/writefreely-swift#33.