### PR TITLE
Log fatal errors and present alert on next launch

### DIFF
--- a/Shared/Extensions/UserDefaults+Extensions.swift
+++ b/Shared/Extensions/UserDefaults+Extensions.swift
@@ -13,6 +13,8 @@ enum WFDefaults {
     static let automaticallyChecksForUpdates = "automaticallyChecksForUpdates"
     static let subscribeToBetaUpdates = "subscribeToBetaUpdates"
     #endif
+    static let didHaveFatalError = "didHaveFatalError"
+    static let fatalErrorDescription = "fatalErrorDescription"
 }
 
 extension UserDefaults {

--- a/Shared/Logging/Logging.swift
+++ b/Shared/Logging/Logging.swift
@@ -1,0 +1,50 @@
+//
+//  Logging.swift
+//  WriteFreely-MultiPlatform
+//
+//  Created by Angelo Stavrow on 2022-06-25.
+//
+
+import Foundation
+import os
+import OSLog
+
+protocol LogWriter {
+    func log(_ message: String, withSensitiveInfo privateInfo: String?, level: OSLogType)
+    func logCrashAndSetFlag(error: Error)
+}
+
+final class Logging {
+
+    private let logger: Logger
+    private let subsystem = Bundle.main.bundleIdentifier!
+
+    init(for category: String = "") {
+        self.logger = Logger(subsystem: subsystem, category: category)
+    }
+
+}
+
+extension Logging: LogWriter {
+
+    func log(
+        _ message: String,
+        withSensitiveInfo privateInfo: String? = nil,
+        level: OSLogType = .default
+    ) {
+        if let privateInfo = privateInfo {
+            logger.log(level: level, "\(message): \(privateInfo, privacy: .sensitive)")
+        } else {
+            logger.log(level: level, "\(message)")
+        }
+    }
+
+    func logCrashAndSetFlag(error: Error) {
+        let errorDescription = error.localizedDescription
+        UserDefaults.shared.set(true, forKey: WFDefaults.didHaveFatalError)
+        UserDefaults.shared.set(errorDescription, forKey: WFDefaults.fatalErrorDescription)
+        logger.log(level: .error, "\(errorDescription)")
+        fatalError(errorDescription)
+    }
+
+}

--- a/Shared/PostCollection/CollectionListModel.swift
+++ b/Shared/PostCollection/CollectionListModel.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import CoreData
+import os
 
 class CollectionListModel: NSObject, ObservableObject {
     @Published var list: [WFACollection] = []
@@ -16,11 +17,12 @@ class CollectionListModel: NSObject, ObservableObject {
         collectionsController.delegate = self
 
         do {
+            Self.logger.info("Fetching collections from local store...")
             try collectionsController.performFetch()
             list = collectionsController.fetchedObjects ?? []
+            Self.logger.notice("Fetched collections from local store.")
         } catch {
-            // FIXME: Errors cannot be thrown out of the CollectionListView property initializer
-            fatalError(LocalStoreError.couldNotFetchCollections.localizedDescription)
+            logCrashAndSetFlag(error: LocalStoreError.couldNotFetchCollections)
         }
     }
 }
@@ -29,6 +31,21 @@ extension CollectionListModel: NSFetchedResultsControllerDelegate {
     func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
         guard let collections = controller.fetchedObjects as? [WFACollection] else { return }
         self.list = collections
+    }
+}
+
+extension CollectionListModel {
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier!,
+        category: String(describing: CollectionListModel.self)
+    )
+
+    private func logCrashAndSetFlag(error: Error) {
+        let errorDescription = error.localizedDescription
+        UserDefaults.shared.set(true, forKey: WFDefaults.didHaveFatalError)
+        UserDefaults.shared.set(errorDescription, forKey: WFDefaults.fatalErrorDescription)
+        Self.logger.critical("\(errorDescription)")
+        fatalError(errorDescription)
     }
 }
 

--- a/Shared/WriteFreely_MultiPlatformApp.swift
+++ b/Shared/WriteFreely_MultiPlatformApp.swift
@@ -56,7 +56,6 @@ struct WriteFreely_MultiPlatformApp: App {
                         helpMsg.append("\n\n\(errorMsg)")
                     }
 
-                    // TODO: - Confirm copy for this alert
                     return Alert(
                         title: Text("Crash Detected"),
                         message: Text(helpMsg),

--- a/Shared/WriteFreely_MultiPlatformApp.swift
+++ b/Shared/WriteFreely_MultiPlatformApp.swift
@@ -30,6 +30,8 @@ struct WriteFreely_MultiPlatformApp: App {
     @State private var selectedTab = 0
     #endif
 
+    @State private var didCrash = UserDefaults.shared.bool(forKey: WFDefaults.didHaveFatalError)
+
     var body: some Scene {
         WindowGroup {
             ContentView()
@@ -48,6 +50,22 @@ struct WriteFreely_MultiPlatformApp: App {
                         }
                     }
                 })
+                .alert(isPresented: $didCrash) {
+                    // TODO: - Confirm copy for this alert
+                    Alert(
+                        title: Text("Crash Detected"),
+                        message: Text(
+                            UserDefaults.shared.object(forKey: WFDefaults.fatalErrorDescription) as? String ??
+                            "Something went horribly wrong!"
+                        ),
+                        dismissButton: .default(
+                            Text("Dismiss"), action: {
+                                UserDefaults.shared.set(false, forKey: WFDefaults.didHaveFatalError)
+                                UserDefaults.shared.removeObject(forKey: WFDefaults.fatalErrorDescription)
+                            }
+                        )
+                    )
+                }
                 .withErrorHandling()
                 .environmentObject(model)
                 .environment(\.managedObjectContext, LocalStorageManager.standard.container.viewContext)

--- a/Shared/WriteFreely_MultiPlatformApp.swift
+++ b/Shared/WriteFreely_MultiPlatformApp.swift
@@ -51,18 +51,21 @@ struct WriteFreely_MultiPlatformApp: App {
                     }
                 })
                 .alert(isPresented: $didCrash) {
+                    var helpMsg = "Alert the humans by sharing what happened on the help forum."
+                    if let errorMsg = UserDefaults.shared.object(forKey: WFDefaults.fatalErrorDescription) as? String {
+                        helpMsg.append("\n\n\(errorMsg)")
+                    }
+
                     // TODO: - Confirm copy for this alert
-                    Alert(
+                    return Alert(
                         title: Text("Crash Detected"),
-                        message: Text(
-                            UserDefaults.shared.object(forKey: WFDefaults.fatalErrorDescription) as? String ??
-                            "Something went horribly wrong!"
+                        message: Text(helpMsg),
+                        primaryButton: .default(
+                            Text("Let us know"), action: didPressCrashAlertButton
                         ),
-                        dismissButton: .default(
-                            Text("Dismiss"), action: {
-                                UserDefaults.shared.set(false, forKey: WFDefaults.didHaveFatalError)
-                                UserDefaults.shared.removeObject(forKey: WFDefaults.fatalErrorDescription)
-                            }
+                        secondaryButton: .cancel(
+                            Text("Dismiss"),
+                            action: resetCrashFlags
                         )
                     )
                 }
@@ -163,4 +166,19 @@ struct WriteFreely_MultiPlatformApp: App {
             }
         }
     }
+
+    private func resetCrashFlags() {
+        UserDefaults.shared.set(false, forKey: WFDefaults.didHaveFatalError)
+        UserDefaults.shared.removeObject(forKey: WFDefaults.fatalErrorDescription)
+    }
+
+    private func didPressCrashAlertButton() {
+        resetCrashFlags()
+        #if os(macOS)
+        NSWorkspace().open(model.helpURL)
+        #else
+        UIApplication.shared.open(model.helpURL)
+        #endif
+    }
+
 }

--- a/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
+++ b/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		17027E25286741B90062EB29 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17027E24286741B80062EB29 /* Logging.swift */; };
+		17027E26286741B90062EB29 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17027E24286741B80062EB29 /* Logging.swift */; };
+		17027E27286757650062EB29 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17027E24286741B80062EB29 /* Logging.swift */; };
 		170A7EC126F5186A00F1CBD4 /* CollectionListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 170A7EC026F5186A00F1CBD4 /* CollectionListModel.swift */; };
 		170A7EC226F5186A00F1CBD4 /* CollectionListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 170A7EC026F5186A00F1CBD4 /* CollectionListModel.swift */; };
 		170DFA34251BBC44001D82A0 /* PostEditorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 170DFA33251BBC44001D82A0 /* PostEditorModel.swift */; };
@@ -178,6 +181,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		17027E24286741B80062EB29 /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		1709ADDF251B9A110053AF79 /* EditorLaunchingPolicy.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = EditorLaunchingPolicy.md; sourceTree = "<group>"; };
 		170A7EC026F5186A00F1CBD4 /* CollectionListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionListModel.swift; sourceTree = "<group>"; };
 		170DFA33251BBC44001D82A0 /* PostEditorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostEditorModel.swift; sourceTree = "<group>"; };
@@ -315,6 +319,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		17027E23286741910062EB29 /* Logging */ = {
+			isa = PBXGroup;
+			children = (
+				17027E24286741B80062EB29 /* Logging.swift */,
+			);
+			path = Logging;
+			sourceTree = "<group>";
+		};
 		1709ADDE251B99D40053AF79 /* Technotes */ = {
 			isa = PBXGroup;
 			children = (
@@ -494,6 +506,7 @@
 				17DF32D024C8B75C00BCE2E3 /* Account */,
 				1756AE7F24CB841200FD7257 /* Extensions */,
 				17275264280997BF003D0A6A /* ErrorHandling */,
+				17027E23286741910062EB29 /* Logging */,
 				1762DCB124EB07680019C4EB /* Models */,
 				17DF32CC24C8B72300BCE2E3 /* Navigation */,
 				1739B8D324EAFAB700DA7421 /* PostEditor */,
@@ -883,6 +896,7 @@
 				172E10202735C64600061372 /* WFACollection+CoreDataClass.swift in Sources */,
 				172E10222735C64600061372 /* WFAPost+CoreDataProperties.swift in Sources */,
 				172E101D2735C5AB00061372 /* LocalStorageModel.xcdatamodeld in Sources */,
+				17027E27286757650062EB29 /* Logging.swift in Sources */,
 				17836C14273EFB870047AF61 /* UserDefaults+Extensions.swift in Sources */,
 				172E10242735C72500061372 /* PreferencesModel.swift in Sources */,
 				172E10172735C2DF00061372 /* EnvironmentValues+Extensions.swift in Sources */,
@@ -933,6 +947,7 @@
 				1756DC0124FEE18400207AB8 /* WFACollection+CoreDataClass.swift in Sources */,
 				17DF32AA24C87D3500BCE2E3 /* WriteFreely_MultiPlatformApp.swift in Sources */,
 				17120DA724E19D11002B9F6C /* SettingsView.swift in Sources */,
+				17027E25286741B90062EB29 /* Logging.swift in Sources */,
 				1727526628099802003D0A6A /* ErrorConstants.swift in Sources */,
 				1756DC0324FEE18400207AB8 /* WFACollection+CoreDataProperties.swift in Sources */,
 				17120DA224E1985C002B9F6C /* AccountModel.swift in Sources */,
@@ -966,6 +981,7 @@
 				17120DAD24E1B99F002B9F6C /* AccountLoginView.swift in Sources */,
 				17D4926727947D780035BD7E /* MacUpdatesViewModel.swift in Sources */,
 				17466626256C0D0600629997 /* MacEditorTextView.swift in Sources */,
+				17027E26286741B90062EB29 /* Logging.swift in Sources */,
 				170A7EC226F5186A00F1CBD4 /* CollectionListModel.swift in Sources */,
 				1727526B2809991A003D0A6A /* ErrorHandling.swift in Sources */,
 				17E5DF8A2543610700DCDC9B /* PostTextEditingView.swift in Sources */,


### PR DESCRIPTION
This PR relates to, but does not close, #204.

In some cases, we can't easily use the alert-on-error solutions offered in #207, #209, #210, and #211, so we have to get creative. In these cases, we log the error to the system log ([OSLog](https://developer.apple.com/documentation/os/oslog)), set a `didHaveFatalError` flag in UserDefaults, and write the localized error description to the `fatalErrorDescription` key in UserDefaults before crashing with a `fatalError()`.

On the next launch, the app checks for this `didHaveFatalError` flag and presents an alert indicating that a crash was detected, along with the stored error description.

Dismissing the alert clears the `didHaveFatalError` and `fatalErrorDescription` values in UserDefaults. Tapping "Let us know" clears those values as well, but also opens the user's preferred browser and navigates to the discuss.write.as help forum.

| Alert | Action |
| :---: | :---: |
| <img src="https://user-images.githubusercontent.com/387655/175537514-dada3912-dba1-4cb1-8d43-f584bfab7953.png" width="300px" /> | <video src="https://user-images.githubusercontent.com/387655/175537570-207aa0da-2ceb-46b1-b815-6009392bdcb6.mp4" width="300px" /> |