### PR TITLE
Embed text editor fields into ScrollView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Mac] New drafts are created in the currently-selected blog, rather than being created in Drafts (or "Anonymous" for Write.as accounts).
 - [Mac] Updated the URL and minimum version of the WriteFreely Swift package.
 - [Mac] Upgraded the Sparkle package to v2.
-- [Mac] The app now prompts you to reach out to our user forums if it detects a crash
+- [Mac] The app now prompts you to reach out to our user forums if it detects a crash.
+- [iOS] The post editor now scrolls in its entirety, including the title field.
 
 ### Fixed
 

--- a/Shared/PostList/PostStatusBadgeView.swift
+++ b/Shared/PostList/PostStatusBadgeView.swift
@@ -14,6 +14,7 @@ struct PostStatusBadgeView: View {
             .padding(EdgeInsets(top: 2.5, leading: 7.5, bottom: 2.5, trailing: 7.5))
             .background(badgeColor)
             .clipShape(RoundedRectangle(cornerRadius: 5.0, style: .circular))
+            .frame(width: .infinity)
     }
 
     func setupBadgeProperties(for status: PostStatus) -> (String, Color) {

--- a/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
+++ b/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
@@ -1054,7 +1054,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CODE_SIGN_ENTITLEMENTS = "ActionExtension-iOS/ActionExtension-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 676;
+				CURRENT_PROJECT_VERSION = 679;
 				DEVELOPMENT_TEAM = TPPAB4YBA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "ActionExtension-iOS/Info.plist";
@@ -1066,7 +1066,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.11;
+				MARKETING_VERSION = 1.0.12;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.abunchtell.WriteFreely-MultiPlatform.ActionExtension-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1085,7 +1085,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CODE_SIGN_ENTITLEMENTS = "ActionExtension-iOS/ActionExtension-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 676;
+				CURRENT_PROJECT_VERSION = 679;
 				DEVELOPMENT_TEAM = TPPAB4YBA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "ActionExtension-iOS/Info.plist";
@@ -1097,7 +1097,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.11;
+				MARKETING_VERSION = 1.0.12;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.abunchtell.WriteFreely-MultiPlatform.ActionExtension-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1228,7 +1228,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "WriteFreely-MultiPlatform (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 676;
+				CURRENT_PROJECT_VERSION = 679;
 				DEVELOPMENT_TEAM = TPPAB4YBA6;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = iOS/Info.plist;
@@ -1237,7 +1237,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.11;
+				MARKETING_VERSION = 1.0.12;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.abunchtell.WriteFreely-MultiPlatform";
 				PRODUCT_NAME = "WriteFreely-MultiPlatform";
 				SDKROOT = iphoneos;
@@ -1254,7 +1254,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "WriteFreely-MultiPlatform (iOS).entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 676;
+				CURRENT_PROJECT_VERSION = 679;
 				DEVELOPMENT_TEAM = TPPAB4YBA6;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = iOS/Info.plist;
@@ -1263,7 +1263,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.11;
+				MARKETING_VERSION = 1.0.12;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.abunchtell.WriteFreely-MultiPlatform";
 				PRODUCT_NAME = "WriteFreely-MultiPlatform";
 				SDKROOT = iphoneos;

--- a/iOS/PostEditor/PostBodyTextView.swift
+++ b/iOS/PostEditor/PostBodyTextView.swift
@@ -21,6 +21,20 @@ class PostBodyCoordinator: NSObject, UITextViewDelegate, NSLayoutManagerDelegate
         _text = text
         _isFirstResponder = isFirstResponder
         self.lineSpacingMultiplier = lineSpacingMultiplier
+
+        super.init()
+
+        updateSize()
+    }
+
+    func updateSize() {
+        DispatchQueue.main.async {
+            guard let view = self.textView else { return }
+            let size = view.sizeThatFits(view.bounds.size)
+            if self.postBodyTextView.height != size.height {
+                self.postBodyTextView.height = size.height
+            }
+        }
     }
 
     func textViewDidChange(_ textView: UITextView) {
@@ -32,6 +46,14 @@ class PostBodyCoordinator: NSObject, UITextViewDelegate, NSLayoutManagerDelegate
     func textViewDidEndEditing(_ textView: UITextView) {
         self.isFirstResponder = false
         self.didBecomeFirstResponder = false
+    }
+
+    func layoutManager(
+        _ layoutManager: NSLayoutManager,
+        didCompleteLayoutFor textContainer: NSTextContainer?,
+        atEnd layoutFinishedFlag: Bool
+    ) {
+        updateSize()
     }
 
     func layoutManager(
@@ -59,6 +81,7 @@ class PostBodyCoordinator: NSObject, UITextViewDelegate, NSLayoutManagerDelegate
 struct PostBodyTextView: UIViewRepresentable {
     @Binding var text: String
     @Binding var textStyle: UIFont
+    @Binding var height: CGFloat
     @Binding var isFirstResponder: Bool
     @State var lineSpacing: CGFloat
 

--- a/iOS/PostEditor/PostTextEditingView.swift
+++ b/iOS/PostEditor/PostTextEditingView.swift
@@ -8,10 +8,12 @@ struct PostTextEditingView: View {
     @State private var appearance: PostAppearance = .serif
     @State private var titleTextStyle: UIFont = UIFont(name: "Lora-Regular", size: 26)!
     @State private var titleTextHeight: CGFloat = 50
+    @State private var bodyTextHeight: CGFloat = 50
     @State private var titleIsFirstResponder: Bool = true
     @State private var bodyTextStyle: UIFont = UIFont(name: "Lora-Regular", size: 17)!
     @State private var bodyIsFirstResponder: Bool = false
     private let lineSpacingMultiplier: CGFloat = 0.5
+    private let textEditorHeight: CGFloat = 50
 
     init(
         post: ObservedObject<WFAPost>,
@@ -25,15 +27,22 @@ struct PostTextEditingView: View {
     }
 
     var titleFieldHeight: CGFloat {
-        let minHeight: CGFloat = 50
+        let minHeight: CGFloat = textEditorHeight
         if titleTextHeight < minHeight {
             return minHeight
         }
         return titleTextHeight
     }
+    var bodyFieldHeight: CGFloat {
+        let minHeight: CGFloat = textEditorHeight
+        if bodyTextHeight < minHeight {
+            return minHeight
+        }
+        return bodyTextHeight
+    }
 
     var body: some View {
-        VStack {
+        ScrollView(.vertical) {
             ZStack(alignment: .topLeading) {
                 if post.title.count == 0 {
                     Text("Title (optional)")
@@ -74,9 +83,11 @@ struct PostTextEditingView: View {
                 PostBodyTextView(
                     text: $post.body,
                     textStyle: $bodyTextStyle,
+                    height: $bodyTextHeight,
                     isFirstResponder: $bodyIsFirstResponder,
                     lineSpacing: horizontalSizeClass == .compact ? lineSpacingMultiplier / 2 : lineSpacingMultiplier
                 )
+                .frame(height: bodyFieldHeight)
                 .accessibilityLabel(Text("Body"))
                 .accessibilityHint(Text("Add or edit the body of your post"))
                 .onChange(of: post.body) { _ in


### PR DESCRIPTION
This PR closes #61 by embedding the title and body text fields into a ScrollView and ensuring the scroll behaviour works as expected.

It also fixes a small papercut bug where status badges would be truncated if they transitions from a shorter label (e.g., "local") to a longer one (e.g., "published").

https://user-images.githubusercontent.com/387655/192148009-3c7d2b59-a8fe-4862-b88c-456d5c39df07.mp4