### PR TITLE
Fix for misaligned badge in post list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Mac] Updated the URL and minimum version of the WriteFreely Swift package.
 - [Mac] Upgraded the Sparkle package to v2.
 - [Mac] The app now prompts you to reach out to our user forums if it detects a crash.
-- [iOS] The post editor now scrolls in its entirety, including the title field.
 
 ### Fixed
 

--- a/Shared/PostList/PostListFilteredView.swift
+++ b/Shared/PostList/PostListFilteredView.swift
@@ -135,6 +135,11 @@ struct PostListFilteredView: View {
 
 struct PostListFilteredView_Previews: PreviewProvider {
     static var previews: some View {
-        return PostListFilteredView(collection: nil, showAllPosts: false, postCount: .constant(999))
+        return PostListFilteredView(
+            collection: nil,
+            showAllPosts: false,
+            postCount: .constant(999)
+        )
+        .environmentObject(WriteFreelyModel())
     }
 }

--- a/Shared/PostList/PostStatusBadgeView.swift
+++ b/Shared/PostList/PostStatusBadgeView.swift
@@ -14,7 +14,6 @@ struct PostStatusBadgeView: View {
             .padding(EdgeInsets(top: 2.5, leading: 7.5, bottom: 2.5, trailing: 7.5))
             .background(badgeColor)
             .clipShape(RoundedRectangle(cornerRadius: 5.0, style: .circular))
-            .frame(maxWidth: .infinity)
     }
 
     func setupBadgeProperties(for status: PostStatus) -> (String, Color) {


### PR DESCRIPTION
Fixes a little regression with the alignment of "local", "edited", and "published" badges on the post list, and cleans up a couple of other little things (redundant entry on the change log, and missing environment object for a SwiftUI preview).

| Broken | Fixed |
| :---: | :---: |
| <img src="https://user-images.githubusercontent.com/387655/199709659-cef5b7b3-e2e2-46fe-8f6f-d8b6e82851fd.PNG" width="300px" /> | <img src="https://user-images.githubusercontent.com/387655/199709702-c941a775-75ba-49a7-b7b9-90ee5db6db92.PNG" width="300px" /> |